### PR TITLE
Fix public URL

### DIFF
--- a/src/containers/Loader/index.js
+++ b/src/containers/Loader/index.js
@@ -7,7 +7,13 @@ import "./styles.scss";
 
 function Loader({ fixed }) {
   const classes = cx("loader-pokeball", { spin: !fixed });
-  return <img className={classes} alt="Loading..." src="/pokeball.svg" />;
+  return (
+    <img
+      className={classes}
+      alt="Loading..."
+      src={`${process.env.PUBLIC_URL}/pokeball.svg`}
+    />
+  );
 }
 
 Loader.propTypes = {

--- a/src/containers/Type/index.js
+++ b/src/containers/Type/index.js
@@ -6,7 +6,7 @@ import "./styles.scss";
 function Type({ name, language }) {
   return (
     <img
-      src={`/types/${language}/${name}.png`}
+      src={`${process.env.PUBLIC_URL}/types/${language}/${name}.png`}
       alt={name}
       className="type-image"
     />

--- a/src/services/PokeApi.js
+++ b/src/services/PokeApi.js
@@ -60,7 +60,7 @@ async function getSpeciesDetails(species) {
   const images = [
     // The API doesn't give us a link to them, however, most of them are present.
     `${OFFICIAL_ARTWORK_BASE_URL}/${data.id}.png`,
-    `/sprites/official-artwork/${data.id}.png`,
+    `${process.env.PUBLIC_URL}/sprites/official-artwork/${data.id}.png`,
     data.sprites.front_default,
     // This URL is to fix some sprites than are not properly loaded at the API yet, like Zeraora
     `${BASE_CONTENT_URL}/sprites/pokemon/${data.id}.png`,
@@ -79,7 +79,7 @@ async function getSpecies({ url }) {
   const names = filterNames(species);
   const flavorText = getFlavorText(species);
   const genera = getGenera(species);
-  const icon = `/icons/${species.id}.png`;
+  const icon = `${process.env.PUBLIC_URL}/icons/${species.id}.png`;
   const details = await getSpeciesDetails(species);
   return {
     id: species.id,


### PR DESCRIPTION
## Summary

This is a quick fix to fix URLs to be prefixes, so react can properly use them at the deploy.
